### PR TITLE
Add missing `;;' operator to case

### DIFF
--- a/rel/files/chunter
+++ b/rel/files/chunter
@@ -176,6 +176,7 @@ case "$1" in
         if [ "$ES" -ne 0 ]; then
             exit $ES
         fi
+        ;;
     ping)
         ## See if the VM is alive
         $NODETOOL ping


### PR DESCRIPTION
Should be self-explanatory.  Chunter does not start without this fix.